### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/CppDockerMakeTemplate/security/code-scanning/2](https://github.com/gvatsal60/CppDockerMakeTemplate/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out the repository and performs linting on markdown files, it likely only requires `contents: read` permissions. This minimal permission level ensures that the workflow can access the repository contents without granting unnecessary write access.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`lint`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
