### PR TITLE
Update postCreateScript.sh

### DIFF
--- a/.devcontainer/postCreateScript.sh
+++ b/.devcontainer/postCreateScript.sh
@@ -47,7 +47,7 @@ readonly ALIAS_SOURCE_URL="https://raw.githubusercontent.com/gvatsal60/Linux-Ali
 # Install Linux aliases from external script using curl and execute immediately
 # Note: Make sure to review scripts fetched from external sources for security reasons
 if command -v curl >/dev/null 2>&1; then
-    curl -fsSL ${ALIAS_SOURCE_URL} | sh
+    curl -fsSL "${ALIAS_SOURCE_URL}" | sh
 else
     echo "Error: curl is not installed. Unable to use Linux aliases"
     exit 1


### PR DESCRIPTION
This pull request makes a minor improvement to the `postCreateScript.sh` by quoting the `ALIAS_SOURCE_URL` variable when used with `curl`. This change helps prevent potential issues if the URL contains special characters or spaces.

- Shell script robustness:
  * Quoted the `ALIAS_SOURCE_URL` variable in the `curl` command within `.devcontainer/postCreateScript.sh` to ensure correct handling of URLs with special characters.